### PR TITLE
hide overflow in install boxes

### DIFF
--- a/_includes/v1/components/install-box.html
+++ b/_includes/v1/components/install-box.html
@@ -17,7 +17,7 @@
     x-on:click="copyToClipboard();"
   >
     <div class="flex items-center">
-      <div class="flex-1 overflow-scroll whitespace-nowrap p-3 py-5">
+      <div class="flex-1 overflow-hidden whitespace-nowrap p-3 py-5">
         brew install dotenvx/brew/dotenvx
       </div>
       <div class="flex-0 pr-3">
@@ -45,7 +45,7 @@
     x-cloak
   >
     <div class="flex items-center">
-      <div class="flex-1 overflow-scroll whitespace-nowrap p-3 py-5">
+      <div class="flex-1 overflow-hidden whitespace-nowrap p-3 py-5">
         curl -fsS https://dotenvx.sh/ | sh
       </div>
       <div class="flex-0 pr-3">


### PR DESCRIPTION
fixes the visual bug where the install boxes show these disabled scrollbars (i'm using chrome 122)
![image](https://github.com/dotenvx/dotenvx.github.io/assets/53496941/a754a31f-ec8b-4873-9c57-f706dd1c3d6e)

after this change:
![image](https://github.com/dotenvx/dotenvx.github.io/assets/53496941/97edf248-71bf-4dae-b096-49f979fd1a98)
