### PR TITLE
fix: typo for Dotenvx github repo

### DIFF
--- a/blog/_posts/2024-06-24-dotenvx-next-generation-config-management.md
+++ b/blog/_posts/2024-06-24-dotenvx-next-generation-config-management.md
@@ -36,7 +36,7 @@ In order of importance, there are three big problems with `dotenv`:
 
 All three pose risks to security, and the first does SIGNIFICANTLY.
 
-**But I think we have a solution to all three today - with [dotenvx](https://gitub.com/dotenvx/dotenvx)**. In reverse problem order:
+**But I think we have a solution to all three today - with [dotenvx](https://github.com/dotenvx/dotenvx)**. In reverse problem order:
 
 * [Run Anywhere](https://github.com/dotenvx/dotenvx?tab=readme-ov-file#run-anywhere) -> *inconsistency across platforms*
 * [Multiple Environments](https://github.com/dotenvx/dotenvx?tab=readme-ov-file#multiple-environments) -> *juggling multiple environments*


### PR DESCRIPTION
I was super excited to learn more about Dotenvx and clicked on the link and was redirected to something weird:

<img width="1792" alt="Screen Shot 2024-06-25 at 11 25 49 AM" src="https://github.com/dotenvx/dotenvx.github.io/assets/949055/731c22f8-b9d8-4ad8-a114-0fa73bcb5aa1">

This should fix it!